### PR TITLE
Use correct mechanism option

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -26,6 +26,19 @@ class qpid::server(
   package { $package_name:
     ensure => $package_ensure
   }
+
+  if $::operatingsystem == 'Fedora' {
+    $mechanism_option = 'ha-mechanism'
+    package {"qpid-cpp-server-ha":
+      ensure => installed,
+    }
+  }
+  else {
+    $mechanism_option = 'cluster-mechanism'
+    package {"qpid-cpp-server-cluster":
+      ensure => installed,
+    }
+  }
  
   file { $config_file:
     ensure  => present,

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -11,7 +11,7 @@ worker-threads=<%= worker_threads %>
 connection-backlog=<%= connection_backlog %>
 auth=<%= auth %>
 realm=<%= realm %>
-cluster-mechanism=<%= cluster_mechanism %>
+<%= mechanism_option %>=<%= cluster_mechanism %>
 <% if log_to_file != 'UNSET' %>
 log-to-file=<%= log_to_file %>
 <% end %>


### PR DESCRIPTION
From qpid-cpp-0.16-1.2 'cluster' subpackage has been renamed to 'ha' subpackage including configuration options. Which means 'cluster-mechanism' option will cause failures on recent Fedora versions.
