### PR TITLE
Allow custer configuration to be optional

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -14,6 +14,7 @@ class qpid::server(
   $auth = 'no',
   $realm = 'QPID',
   $log_to_file = 'UNSET',
+  $clustered = false,
   $cluster_mechanism = 'ANONYMOUS'
 ) {
 
@@ -27,19 +28,23 @@ class qpid::server(
     ensure => $package_ensure
   }
 
-  if $::operatingsystem == 'Fedora' {
-    $mechanism_option = 'ha-mechanism'
-    package {"qpid-cpp-server-ha":
-      ensure => installed,
+  if $clustered == true {
+    case $::operatingsystem {
+      fedora: {
+        $mechanism_option = 'ha-mechanism'
+        package {"qpid-cpp-server-ha":
+          ensure => installed,
+        }
+      }
+      default: {
+        $mechanism_option = 'cluster-mechanism'
+        package {"qpid-cpp-server-cluster":
+          ensure => installed,
+        }
+      }
     }
   }
-  else {
-    $mechanism_option = 'cluster-mechanism'
-    package {"qpid-cpp-server-cluster":
-      ensure => installed,
-    }
-  }
- 
+
   file { $config_file:
     ensure  => present,
     owner   => 'root',

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -11,7 +11,9 @@ worker-threads=<%= worker_threads %>
 connection-backlog=<%= connection_backlog %>
 auth=<%= auth %>
 realm=<%= realm %>
+<% if clustered == true %>
 <%= mechanism_option %>=<%= cluster_mechanism %>
+<% end %>
 <% if log_to_file != 'UNSET' %>
 log-to-file=<%= log_to_file %>
 <% end %>


### PR DESCRIPTION
Add in a clustered configuration option (set by default to false) to
control if clustered packages and configuration are used or not
