### PR TITLE
Improve dependencies so the NSS database is always created first.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,12 +70,11 @@ class qpid::server(
     }
     package { $ssl_package_name:
       ensure => $ssl_package_ensure,
-      before => File['/etc/pki/qpidd'],
+      before => Nssdb::Create['qpidd'],
     }
     nssdb::create {"qpidd":
       owner_id => 'qpidd',
       group_id => 'qpidd',
-      basedir => '/etc/pki',
       password => $ssl_database_password,
       cacert => $ssl_ca,
     }


### PR DESCRIPTION
The dependencies needed some tweaking such that the qpid packages are installed but the NSS database still gets created first. The reason is that the qpidd user needs to be created in order to set file permissions correctly.
