### PR TITLE
Actual output should not be ignored with sasldblistusers2

### DIFF
--- a/lib/puppet/provider/qpid_user/saslpasswd2.rb
+++ b/lib/puppet/provider/qpid_user/saslpasswd2.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:qpid_user).provide(:saslpasswd2) do
 
   def exists?
     begin
-      out = sasldblistusers2('-f', resource[:file]).split(/\n/)[1..-2].detect do |line|
+      out = sasldblistusers2('-f', resource[:file]).split(/\n/).detect do |line|
         line.match(/^#{resource[:name]}@#{resource[:realm]}:.*$/)
       end
     rescue


### PR DESCRIPTION
Not sure if this is different for other platforms but on EL 6 the
current code would ignore lines with actual output which obviously
isn't very desirable. Not sure if other platforms show some kind
of headers / footers with meta-information that need be stripped
away. But then again, unless that meta stuff is in the format of
._@._:.*, the match will be bad anyway and therefore not change the
behavior at all.
