### PR TITLE
Increase the number of max_connections

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,7 +9,7 @@ class qpid::server(
   $service_ensure = running,
   $service_enable = true,
   $port = '5672',
-  $max_connections = '500',
+  $max_connections = '65535',
   $worker_threads = '17',
   $connection_backlog = '10',
   $auth = 'no',


### PR DESCRIPTION
Increase the max_connection configure directive to UINT16_MAX

From rhbz#1042529:
The qpid puppet module defaults qpid brokers to have a max number of connections of 500.  This is only enough to support about 10 Nova Compute nodes.

It was advised by the qpid team to change the value of the puppet module to UINT16_MAX by default to prevent running out of available connections.
