### PR TITLE
Fixes Fedora qpid ssl package

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -70,9 +70,11 @@ class qpid::server(
     if $ssl_database_password == undef {
       fail('ssl_database_passowrd must be set')
     }
-    package { $ssl_package_name:
-      ensure => $ssl_package_ensure,
-      before => Nssdb::Create['qpidd'],
+    if $::operatingsystem == 'Fedora' and is_integer($::operatingsystemrelease) and $::operatingsystemrelease <= 19 {
+      package { $ssl_package_name:
+        ensure => $ssl_package_ensure,
+        before => Nssdb::Create['qpidd'],
+      }
     }
     nssdb::create {"qpidd":
       owner_id => 'qpidd',


### PR DESCRIPTION
```
This patch fixes the qpid-cpp-server-ssl package
now included in qpid-cpp-server in Fedora 20
```
