### PR TITLE
Ensure qpid persistent data uses correct path

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -18,6 +18,7 @@ class qpid::server(
   $log_to_file = 'UNSET',
   $clustered = false,
   $cluster_mechanism = 'ANONYMOUS',
+  $data_dir = '/var/lib/qpidd',
   $ssl = false,
   $ssl_package_name = 'qpid-cpp-server-ssl',
   $ssl_package_ensure = present,

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -11,6 +11,7 @@ worker-threads=<%= @worker_threads %>
 connection-backlog=<%= @connection_backlog %>
 auth=<%= @auth %>
 realm=<%= @realm %>
+data-dir=<% @data_dir %>
 <% if @clustered == true %>
 <%= @mechanism_option %>=<%= @cluster_mechanism %>
 <% end %>


### PR DESCRIPTION
Path for data-dir is modifiable and by default points to /var/lib/qpidd
