### PR TITLE
Ensure installing always the latest package

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -4,7 +4,7 @@
 class qpid::server(
   $config_file = '/etc/qpidd.conf',
   $package_name = 'qpid-cpp-server',
-  $package_ensure = present,
+  $package_ensure = latest,
   $service_name = 'qpidd',
   $service_ensure = running,
   $service_enable = true,


### PR DESCRIPTION
There are numerous known issues w/ the 0.14 version of qpid in the rhel6 channels.
In the channel there's qpid version >= 0.18 availabe but version 0.14 gets
installed so we need to ensure the latest package is installed.
