### PR TITLE
Added support for max-negotiate-time

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -11,6 +11,7 @@ class qpid::server(
   $manage_service = true,
   $port = '5672',
   $max_connections = '65530',
+  $max_negotiate_time = 'UNSET',
   $worker_threads = '17',
   $connection_backlog = '10',
   $auth = 'no',
@@ -36,6 +37,7 @@ class qpid::server(
   validate_re($worker_threads, '\d+')
   validate_re($connection_backlog, '\d+')
   validate_re($auth, '^(yes$|no$)')
+  validate_re($max_negotiate_time, '\d+')
 
   package { $package_name:
     ensure => $package_ensure

--- a/templates/qpidd.conf.erb
+++ b/templates/qpidd.conf.erb
@@ -9,6 +9,9 @@ port=<%= @port %>
 max-connections=<%= @max_connections %>
 worker-threads=<%= @worker_threads %>
 connection-backlog=<%= @connection_backlog %>
+<% if @max_negotiate_time != 'UNSET' %>
+max-negotiate-time=<%= @max_negotiate_time %>
+<% end %>
 auth=<%= @auth %>
 realm=<%= @realm %>
 data-dir=<%= @data_dir %>


### PR DESCRIPTION
Added the 'max-negotiate-time' parameter in order to implement Red Hat's qpid tuning recommendations for OpenStack Havana (RHEL OSP 4)
